### PR TITLE
Utiliser une popup thématique pour supprimer une photo

### DIFF
--- a/src/components/jouer/Scoreboard.tsx
+++ b/src/components/jouer/Scoreboard.tsx
@@ -192,14 +192,32 @@ export default function Scoreboard({ partie }: { partie: Partie }) {
                   />
                 </button>
                 {partie.etat === 'en_cours' && (
-                  <Button
-                    size="icon"
-                    variant="destructive"
-                    className="absolute top-1 right-1"
-                    onClick={(e) => { e.stopPropagation(); if (window.confirm('Supprimer cette photo ?')) supprimerPhoto(partie.id, ph.id); }}
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        size="icon"
+                        variant="destructive"
+                        className="absolute top-1 right-1"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertHeader>
+                        <AlertDialogTitle>Supprimer la photo ?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Cette action supprimera définitivement la photo.
+                        </AlertDialogDescription>
+                      </AlertHeader>
+                      <AlertFooter>
+                        <AlertDialogCancel>Annuler</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => supprimerPhoto(partie.id, ph.id)}>
+                          Supprimer
+                        </AlertDialogAction>
+                      </AlertFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 )}
               </div>
             ))}


### PR DESCRIPTION
## Résumé
- Remplacement de la boîte de confirmation native par un `AlertDialog` stylisé lors de la suppression d'une photo

## Tests
- `npm test` *(échoué: Missing script "test")*
- `npm run lint` *(échoué: 16 errors, 10 warnings)*
- `npx eslint src/components/jouer/Scoreboard.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689c97bc2fa483269ede1a29ec11a946