### PR TITLE
doc: explain optional opencv analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,29 @@ npm run dev
 ```sh
 npm run build
 ```
+
+## Optional native image analysis
+
+The API can analyze photos to determine which boule is closest to the jack. A
+pure JavaScript version is bundled, but you can enable a faster native
+implementation using [opencv4nodejs](https://www.npmjs.com/package/opencv4nodejs).
+
+1. Install OpenCV on your system (Ubuntu example):
+   ```bash
+   sudo apt-get update && sudo apt-get install -y build-essential cmake libopencv-dev
+   ```
+2. Install the Node binding:
+   ```bash
+   npm install opencv4nodejs
+   ```
+3. Start the API server:
+   ```bash
+   npm run server
+   ```
+4. Send a photo to be analyzed:
+   ```bash
+   curl -F "photo=@/path/to/image.jpg" http://localhost:3001/api/analyze
+   ```
+
+If `opencv4nodejs` is not installed, the server falls back to the bundled
+WebAssembly implementation, which is slower but still functional.

--- a/server.js
+++ b/server.js
@@ -6,13 +6,15 @@ import fs from 'node:fs/promises';
 import { saveBase64AsJpeg } from './utils/image-store.mjs';
 
 // Attempt to load the optional OpenCV-based analyzer. If the dependency is not
-// installed (e.g. opencv4nodejs is missing), the API routes provided by
+// installed (e.g. `opencv4nodejs` is missing), the native upload route from
 // `opencv-analyze.mjs` will simply not be mounted and a warning is logged.
 let analyzerRouter;
 try {
   ({ router: analyzerRouter } = await import('./server/opencv-analyze.mjs'));
 } catch (err) {
-  console.warn('opencv4nodejs not installed; /api/analyze disabled');
+  console.warn(
+    'opencv4nodejs not installed; using WebAssembly fallback. Install "opencv4nodejs" to enable the native /api/analyze route.'
+  );
 }
 
 const app = express();


### PR DESCRIPTION
## Summary
- clarify server fallback message when opencv4nodejs is missing
- document how to enable optional native OpenCV analyzer

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: eslint errors)


------
https://chatgpt.com/codex/tasks/task_e_689c99dd2dd48326a4d0a3435611c69f